### PR TITLE
Implement marketing pages and nav

### DIFF
--- a/app/blog/hello-world/page.tsx
+++ b/app/blog/hello-world/page.tsx
@@ -1,0 +1,12 @@
+export const metadata = {
+  title: "Hello World - PESOS Blog",
+};
+
+export default function HelloWorldPost() {
+  return (
+    <article className="prose mx-auto py-16">
+      <h1>Hello World</h1>
+      <p>I'm kicking this thing off. Here's what PESOS is for...</p>
+    </article>
+  );
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "Blog - PESOS",
+};
+
+const posts = [
+  { slug: "hello-world", title: "Hello World" },
+];
+
+export default function BlogIndex() {
+  return (
+    <div className="max-w-3xl mx-auto py-16">
+      <h1 className="text-3xl font-bold mb-6">Blog</h1>
+      <ul className="space-y-2">
+        {posts.map((post) => (
+          <li key={post.slug}>
+            <Link href={`/blog/${post.slug}`} className="text-blue-600 underline">
+              {post.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,150 +1,42 @@
 "use client";
 
-export const dynamic = "force-dynamic";
-
-import { useUser } from "@clerk/nextjs";
+import { useUser, SignUpButton } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
-import LandingPageWithUsername from "@/components/LandingPageWithUsername";
-import Spinner from "@/components/Spinner";
-
-// Client-side component to handle localStorage
-function LocalStorageHandler({
-  onUsernameChange,
-}: {
-  onUsernameChange: (username: string | null) => void;
-}) {
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-
-    const storedUsername = localStorage.getItem("chosenUsername");
-    onUsernameChange(storedUsername);
-
-    const handleStorageChange = (e: StorageEvent) => {
-      if (e.key === "chosenUsername") {
-        onUsernameChange(e.newValue);
-      }
-    };
-
-    window.addEventListener("storage", handleStorageChange);
-
-    return () => {
-      window.removeEventListener("storage", handleStorageChange);
-    };
-  }, [onUsernameChange]);
-
-  return null;
-}
+import { useEffect } from "react";
 
 export default function Page() {
   const { user, isLoaded } = useUser();
   const router = useRouter();
-  const [isRedirecting, setIsRedirecting] = useState(true);
-  const [localUsername, setLocalUsername] = useState<string | null>(null);
-
-  // Add effect to log state changes
-  useEffect(() => {
-    console.log("[Page] State updated:", {
-      isLoaded,
-      isRedirecting,
-      hasUser: !!user,
-      localUsername,
-    });
-  }, [isLoaded, isRedirecting, user, localUsername]);
 
   useEffect(() => {
-    if (!isLoaded) return;
-
-    async function checkUserAndRedirect() {
-      if (user) {
-        // Check if user has a username in Clerk metadata
-        const hasClerkUsername = user.publicMetadata?.chosenUsername;
-        console.log("[Page] Clerk username:", hasClerkUsername);
-        console.log("[Page] Local username:", localUsername);
-
-        // If we have a username in localStorage but user isn't in database yet, create them
-        if (localUsername && localUsername.trim() !== "") {
-          console.log(
-            "[Page] Found username in localStorage, attempting to create user..."
-          );
-          try {
-            // Try to create the user
-            const createRes = await fetch("/api/createUser", {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                username: localUsername,
-                clerkId: user.id,
-              }),
-            });
-
-            const createData = await createRes.json();
-            console.log("[Page] Create user response:", createData);
-
-            if (createData.success) {
-              console.log(
-                "[Page] Successfully created user, proceeding to dashboard"
-              );
-              router.replace("/dashboard");
-              return;
-            }
-          } catch (error) {
-            console.error("[Page] Error auto-creating user:", error);
-          }
-        }
-
-        // Check if user exists in database
-        console.log("[Page] Verifying user exists in database");
-        try {
-          const verifyRes = await fetch("/api/getLocalUser", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              clerkId: user.id,
-              chosenUsername: localUsername || hasClerkUsername,
-            }),
-          });
-
-          const verifyData = await verifyRes.json();
-          console.log("[Page] Database verification result:", verifyData);
-
-          if (!verifyData.localUser) {
-            console.log(
-              "[Page] User not found in database, showing landing page"
-            );
-            setIsRedirecting(false);
-            return;
-          }
-
-          // User exists in database, proceed with redirect
-          console.log("[Page] User verified, redirecting to dashboard");
-          router.replace("/dashboard");
-        } catch (error) {
-          console.error("[Page] Error verifying user:", error);
-          setIsRedirecting(false);
-        }
-      } else {
-        console.log("[Page] No user, showing landing page");
-        setIsRedirecting(false);
-      }
+    if (isLoaded && user) {
+      router.replace("/dashboard");
     }
+  }, [isLoaded, user, router]);
 
-    checkUserAndRedirect();
-  }, [user, router, isLoaded, localUsername]);
-
-  if (!isLoaded || isRedirecting) {
+  if (!isLoaded) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-white">
-        <Spinner />
+      <div className="min-h-screen flex items-center justify-center bg-black">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
       </div>
     );
   }
 
-  console.log("[Page] Rendering LandingPageWithUsername");
+  if (user) return null;
+
   return (
-    <>
-      <LocalStorageHandler onUsernameChange={setLocalUsername} />
-      <LandingPageWithUsername />
-    </>
+    <div className="min-h-screen flex flex-col items-center justify-center text-center bg-black text-white px-4">
+      <h1 className="text-3xl md:text-5xl font-bold mb-4">
+        PESOS backs up your projects once a week.
+      </h1>
+      <p className="mb-6 text-lg md:text-xl">
+        Keep your creative work safe with automatic weekly backups.
+      </p>
+      <SignUpButton mode="modal">
+        <button className="px-6 py-3 bg-white text-black rounded-lg hover:bg-gray-200">
+          Get Started
+        </button>
+      </SignUpButton>
+    </div>
   );
 }

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,0 +1,12 @@
+export const metadata = {
+  title: "Pricing - PESOS",
+};
+
+export default function PricingPage() {
+  return (
+    <div className="max-w-3xl mx-auto py-16">
+      <h1 className="text-3xl font-bold mb-4">Pricing</h1>
+      <p className="text-gray-700">Pricing details coming soon.</p>
+    </div>
+  );
+}

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { useState } from "react";
+import Link from "next/link";
+import { Menu, X } from "lucide-react";
+
+export default function NavBar() {
+  const [open, setOpen] = useState(false);
+  const navItems = [
+    { href: "/", label: "Home" },
+    { href: "/about", label: "About" },
+    { href: "/pricing", label: "Pricing" },
+    { href: "/blog", label: "Blog" },
+  ];
+
+  return (
+    <nav className="relative">
+      <button
+        className="md:hidden text-gray-600"
+        onClick={() => setOpen(!open)}
+        aria-label="Toggle navigation"
+      >
+        {open ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
+      </button>
+      <div
+        className={`${
+          open ? "flex" : "hidden"
+        } absolute z-10 top-full left-0 w-full bg-white flex-col md:static md:flex md:flex-row md:items-center md:space-x-4 md:w-auto`}
+      >
+        {navItems.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className="block px-4 py-2 text-gray-600 hover:underline"
+            onClick={() => setOpen(false)}
+          >
+            {item.label}
+          </Link>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/components/root-layout-inner.tsx
+++ b/components/root-layout-inner.tsx
@@ -15,6 +15,7 @@ import { usePathname } from "next/navigation";
 import UsernameModal from "./username-modal";
 import DBErrorScreen from "./db-error-screen";
 import { Settings, Download, Loader2 } from "lucide-react";
+import NavBar from "./NavBar";
 import FeedEditor from "@/components/FeedEditor";
 
 interface FeedEntry {
@@ -255,13 +256,8 @@ export function RootLayoutInner({ children, inter }: RootLayoutInnerProps) {
                 </SignedOut>
               </div>
               <div className="flex items-center space-x-4">
+                <NavBar />
                 <SignedIn>
-                  <Link
-                    href="/about"
-                    className="text-gray-600 no-underline hover:underline"
-                  >
-                    About
-                  </Link>
                   {pathname !== "/dashboard/all_posts" && (
                     <>
                       <button
@@ -328,6 +324,16 @@ export function RootLayoutInner({ children, inter }: RootLayoutInnerProps) {
           </p>
         </div>
       </main>
+      <footer className="bg-white border-t">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 text-center">
+          <p className="text-sm text-gray-600">
+            Need help?{' '}
+            <a href="mailto:support@pesos.site" className="underline">
+              support@pesos.site
+            </a>
+          </p>
+        </div>
+      </footer>
       {shouldShowUsernameModal && <UsernameModal />}
       {showFeedEditor && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">


### PR DESCRIPTION
## Summary
- add responsive `NavBar` with menu toggle
- show nav and footer support link in root layout
- replace home page with marketing splash
- add placeholder blog and pricing pages
- create first blog post

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d6ec3993c832c8fad98500a9aea5b