### PR TITLE
Restore username prompt and add basic tests

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,42 +1,150 @@
 "use client";
 
-import { useUser, SignUpButton } from "@clerk/nextjs";
+export const dynamic = "force-dynamic";
+
+import { useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import LandingPageWithUsername from "@/components/LandingPageWithUsername";
+import Spinner from "@/components/Spinner";
+
+// Client-side component to handle localStorage
+function LocalStorageHandler({
+  onUsernameChange,
+}: {
+  onUsernameChange: (username: string | null) => void;
+}) {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const storedUsername = localStorage.getItem("chosenUsername");
+    onUsernameChange(storedUsername);
+
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key === "chosenUsername") {
+        onUsernameChange(e.newValue);
+      }
+    };
+
+    window.addEventListener("storage", handleStorageChange);
+
+    return () => {
+      window.removeEventListener("storage", handleStorageChange);
+    };
+  }, [onUsernameChange]);
+
+  return null;
+}
 
 export default function Page() {
   const { user, isLoaded } = useUser();
   const router = useRouter();
+  const [isRedirecting, setIsRedirecting] = useState(true);
+  const [localUsername, setLocalUsername] = useState<string | null>(null);
+
+  // Add effect to log state changes
+  useEffect(() => {
+    console.log("[Page] State updated:", {
+      isLoaded,
+      isRedirecting,
+      hasUser: !!user,
+      localUsername,
+    });
+  }, [isLoaded, isRedirecting, user, localUsername]);
 
   useEffect(() => {
-    if (isLoaded && user) {
-      router.replace("/dashboard");
-    }
-  }, [isLoaded, user, router]);
+    if (!isLoaded) return;
 
-  if (!isLoaded) {
+    async function checkUserAndRedirect() {
+      if (user) {
+        // Check if user has a username in Clerk metadata
+        const hasClerkUsername = user.publicMetadata?.chosenUsername;
+        console.log("[Page] Clerk username:", hasClerkUsername);
+        console.log("[Page] Local username:", localUsername);
+
+        // If we have a username in localStorage but user isn't in database yet, create them
+        if (localUsername && localUsername.trim() !== "") {
+          console.log(
+            "[Page] Found username in localStorage, attempting to create user..."
+          );
+          try {
+            // Try to create the user
+            const createRes = await fetch("/api/createUser", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                username: localUsername,
+                clerkId: user.id,
+              }),
+            });
+
+            const createData = await createRes.json();
+            console.log("[Page] Create user response:", createData);
+
+            if (createData.success) {
+              console.log(
+                "[Page] Successfully created user, proceeding to dashboard"
+              );
+              router.replace("/dashboard");
+              return;
+            }
+          } catch (error) {
+            console.error("[Page] Error auto-creating user:", error);
+          }
+        }
+
+        // Check if user exists in database
+        console.log("[Page] Verifying user exists in database");
+        try {
+          const verifyRes = await fetch("/api/getLocalUser", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              clerkId: user.id,
+              chosenUsername: localUsername || hasClerkUsername,
+            }),
+          });
+
+          const verifyData = await verifyRes.json();
+          console.log("[Page] Database verification result:", verifyData);
+
+          if (!verifyData.localUser) {
+            console.log(
+              "[Page] User not found in database, showing landing page"
+            );
+            setIsRedirecting(false);
+            return;
+          }
+
+          // User exists in database, proceed with redirect
+          console.log("[Page] User verified, redirecting to dashboard");
+          router.replace("/dashboard");
+        } catch (error) {
+          console.error("[Page] Error verifying user:", error);
+          setIsRedirecting(false);
+        }
+      } else {
+        console.log("[Page] No user, showing landing page");
+        setIsRedirecting(false);
+      }
+    }
+
+    checkUserAndRedirect();
+  }, [user, router, isLoaded, localUsername]);
+
+  if (!isLoaded || isRedirecting) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-black">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
+      <div className="min-h-screen flex items-center justify-center bg-white">
+        <Spinner />
       </div>
     );
   }
 
-  if (user) return null;
-
+  console.log("[Page] Rendering LandingPageWithUsername");
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center text-center bg-black text-white px-4">
-      <h1 className="text-3xl md:text-5xl font-bold mb-4">
-        PESOS backs up your projects once a week.
-      </h1>
-      <p className="mb-6 text-lg md:text-xl">
-        Keep your creative work safe with automatic weekly backups.
-      </p>
-      <SignUpButton mode="modal">
-        <button className="px-6 py-3 bg-white text-black rounded-lg hover:bg-gray-200">
-          Get Started
-        </button>
-      </SignUpButton>
-    </div>
+    <>
+      <LocalStorageHandler onUsernameChange={setLocalUsername} />
+      <LandingPageWithUsername />
+    </>
   );
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "tsc -p tsconfig.test.json && node build/tests/validateUsername.test.js"
   },
   "dependencies": {
     "@clerk/nextjs": "^4.23.2",
@@ -45,7 +46,8 @@
     "tailwindcss-animate": "^1.0.7",
     "typescript": "5.1.6",
     "xml2js": "^0.6.0",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "clsx": "^1.2.1"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",

--- a/tests/validateUsername.test.ts
+++ b/tests/validateUsername.test.ts
@@ -1,0 +1,13 @@
+import { validateUsername } from '../lib/utils';
+import assert from 'node:assert';
+import { test } from 'node:test';
+
+test('accepts valid usernames', () => {
+  assert.strictEqual(validateUsername('user_1').isValid, true);
+});
+
+test('rejects short usernames', () => {
+  const result = validateUsername('ab');
+  assert.strictEqual(result.isValid, false);
+});
+

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "build",
+    "rootDir": ".",
+    "typeRoots": ["./node_modules/@types"]
+  },
+  "include": ["lib/utils.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- revert landing page so it again prompts for a username
- add a bare-bones test suite using Node's test runner
- declare clsx dependency and simplify test tsconfig

## Testing
- `npm test` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6842bf159e08832ca4f3f63c2d638e7f