### PR TITLE
Fix check-username route for dynamic usage

### DIFF
--- a/app/api/active-sources/route.ts
+++ b/app/api/active-sources/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prismadb";
 import { auth } from "@clerk/nextjs";
 
+export const dynamic = "force-dynamic";
+
 export async function GET() {
   try {
     const { userId } = auth();

--- a/app/api/check-username/route.ts
+++ b/app/api/check-username/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prismadb";
 
+export const dynamic = "force-dynamic";
+
 // Add reserved usernames
 const RESERVED_USERNAMES = [
   "dashboard",

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Setup script to install dependencies using Bun.
+# Runs in prebuild environment before network access is disabled.
+
+set -euo pipefail
+
+# Install all dependencies defined in package.json (including Next.js)
+echo "Installing packages with bun..."
+bun install
+


### PR DESCRIPTION
## Summary
- mark API routes as dynamic so Next.js executes them per request
- add newline to end of `active-sources` route file

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683d7804eae4832cb89409138f24b9eb