### PR TITLE
Add initial test setup

### DIFF
--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { calculateMetrics, validateUsername } from '../utils';
+
+const dayMs = 24 * 60 * 60 * 1000;
+
+describe('calculateMetrics', () => {
+  it('computes metrics for sample feed items', () => {
+    const items = [
+      { title: 'a', link: '1', pubDate: '2023-01-03T00:00:00Z', content: 'aaa' },
+      { title: 'b', link: '2', pubDate: '2023-01-02T00:00:00Z', content: 'bb' },
+      { title: 'c', link: '3', pubDate: '2023-01-01T00:00:00Z', content: 'c' },
+    ];
+
+    const result = calculateMetrics(items);
+
+    expect(result.totalPosts).toBe(3);
+    expect(result.averageTimeBetweenPosts).toBe(dayMs);
+    expect(result.medianTimeBetweenPosts).toBe(dayMs);
+    expect(result.averageLengthOfPosts).toBe(2);
+  });
+});
+
+describe('validateUsername', () => {
+  it('validates usernames correctly', () => {
+    expect(validateUsername('user_123').isValid).toBe(true);
+    const short = validateUsername('ab');
+    expect(short.isValid).toBe(false);
+    expect(short.error).toMatch(/at least 3/);
+
+    const invalid = validateUsername('invalid!');
+    expect(invalid.isValid).toBe(false);
+    expect(invalid.error).toMatch(/letters, numbers/);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@clerk/nextjs": "^4.23.2",
@@ -51,6 +52,7 @@
     "@tailwindcss/typography": "^0.5.16",
     "@types/pg": "^8.11.11",
     "@types/xml2js": "^0.4.14",
-    "prisma": "^5.10.2"
+    "prisma": "^5.10.2",
+    "vitest": "^1.5.0"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary
- add vitest and a simple test script
- configure vitest
- create tests for `calculateMetrics` and `validateUsername`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c4de7a88832c99684ec70d24561a