### PR TITLE
Add setup script for Codex

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Install dependencies using Bun before network cutoff
+bun install --frozen-lockfile --no-progress


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` to install deps before network cutoff
- use Bun for the installation instead of npm

## Testing
- `bun install --frozen-lockfile --no-progress` *(fails: 403 errors from registry)*

------
https://chatgpt.com/codex/tasks/task_e_6842c93164a8832cb67edbf53e47ea07