### PR TITLE
Identify tasks for PESOS project

### DIFF
--- a/chronicler.md
+++ b/chronicler.md
@@ -4,6 +4,16 @@ This is the official log of what has happened in PESOS. Every update should be d
 
 ---
 
+## 2025-01-13
+
+**Planned 5 new Codex tasks based on end state priorities.**  
+Analyzed current project state and identified bite-sized, high-impact tasks aligned with the "calm, trustworthy" vision. Added tasks for: Enhanced Status Dashboard, Mobile Dashboard Experience, Admin Monitoring Dashboard, Notification System Foundation, and Data Export Enhancement. These tasks are designed to move PESOS closer to the minimal, elegant user experience described in the end state while building necessary production infrastructure.
+
+**Reorganized todo.md structure.**  
+Created new "Dashboard & Status" high-priority section and "Notifications & Communication" medium-priority section to better organize the growing task list. Emphasized tasks that support the core vision of calm confidence and quiet competence.
+
+---
+
 ## 2025-06-08
 
 **Wrote `agents.md` scaffold.**  

--- a/todo.md
+++ b/todo.md
@@ -36,14 +36,29 @@ A running list of tasks related to PESOS. May be edited by humans or agents.
   - [x] Markdown export
   - [x] CSV export
 
+### Dashboard & Status (New Priority)
+
+- [ ] **Enhanced Status Dashboard** - Improve main dashboard with calm confidence
+  - [ ] Queue status display ("5 items queued, processing in 2 hours")
+  - [ ] Last backup timestamp with friendly language
+  - [ ] System health indicators
+  - [ ] Remove manual fetch buttons (per end state requirements)
+
+- [ ] **Data Export Enhancement** - Polish existing export functionality
+  - [ ] Better export UI/UX
+  - [ ] Export status tracking
+  - [ ] Clear documentation of data formats
+  - [ ] Preview before download
+
 ## Medium Priority
 
 ### Mobile Experience
 
-- [ ] Design and implement mobile interface
-  - [ ] Background image system
-  - [ ] Status text display
-  - [ ] Minimal UI components
+- [ ] **Mobile Dashboard Experience** - Create minimal mobile interface
+  - [ ] Simple background image system
+  - [ ] Clean status text ("All good! 309 items stored. Last one 10 days ago")
+  - [ ] Mobile-optimized dashboard view
+  - [ ] "Postcard from your archive robot" feel
 - [ ] Create mobile-optimized views
   - [ ] Dashboard
   - [ ] Settings
@@ -51,14 +66,23 @@ A running list of tasks related to PESOS. May be edited by humans or agents.
 
 ### Admin Features
 
-- [ ] Basic admin dashboard
+- [ ] **Admin Monitoring Dashboard** - Build foundational admin interface
   - [ ] System status monitoring
-  - [ ] User management
-  - [ ] Log viewing
+  - [ ] Basic user stats
+  - [ ] Processing queue visibility
+  - [ ] Error log viewing (verbose/diagnosable)
 - [ ] Logging system
   - [ ] Backup logs
   - [ ] Queue logs
   - [ ] Error tracking
+
+### Notifications & Communication
+
+- [ ] **Notification System Foundation** - Implement email/notification infrastructure
+  - [ ] Optional email field in user profiles
+  - [ ] Basic notification preferences
+  - [ ] Email templates for backup success/failure
+  - [ ] In-app notification system
 
 ## Future Features
 


### PR DESCRIPTION
I made the following changes to structure the project's next steps and document progress:

*   I updated `chronicler.md` to log the recent planning session. This entry, dated "2025-01-13", documents the identification of 5 new Codex tasks and the subsequent reorganization of `todo.md`, emphasizing their alignment with the "calm, trustworthy" vision for PESOS.
*   I significantly modified `todo.md` to incorporate and prioritize the new tasks:
    *   I introduced a new "Dashboard 