### PR TITLE
Update PESOS logo

### DIFF
--- a/chronicler.md
+++ b/chronicler.md
@@ -80,3 +80,6 @@ Appended a simple entry as requested.
 
 **Marked "fix codex" task complete.**
 Spent time ensuring Codex and Cursor's agents had everything necessary to be awesome.
+## 2025-06-08
+
+**Added new PesosLogo and updated header.** Replaced text logo with a simple clock-style icon featuring a P.

--- a/components/PesosLogo.tsx
+++ b/components/PesosLogo.tsx
@@ -1,0 +1,44 @@
+"use client";
+import React from "react";
+
+export default function PesosLogo({ className = "w-8 h-8" }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 32 32"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="16" cy="16" r="15" fill="black" />
+      <text
+        x="16"
+        y="21"
+        textAnchor="middle"
+        fontFamily="Arial, sans-serif"
+        fontSize="16"
+        fill="white"
+        fontWeight="bold"
+      >
+        P
+      </text>
+      <line
+        x1="16"
+        y1="16"
+        x2="16"
+        y2="9"
+        stroke="white"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <line
+        x1="16"
+        y1="16"
+        x2="22"
+        y2="16"
+        stroke="white"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/components/root-layout-inner.tsx
+++ b/components/root-layout-inner.tsx
@@ -17,6 +17,7 @@ import DBErrorScreen from "./db-error-screen";
 import { Settings, Download, Loader2 } from "lucide-react";
 import NavBar from "./NavBar";
 import FeedEditor from "@/components/FeedEditor";
+import PesosLogo from "./PesosLogo";
 
 interface FeedEntry {
   id: string;
@@ -241,17 +242,15 @@ export function RootLayoutInner({ children, inter }: RootLayoutInnerProps) {
             <div className="flex justify-between items-center">
               <div>
                 <SignedIn>
-                  <Link href="/dashboard">
-                    <h1 className="text-2xl font-bold text-gray-900 hover:text-gray-700">
-                      PESOS
-                    </h1>
+                  <Link href="/dashboard" className="flex items-center">
+                    <PesosLogo className="w-8 h-8" />
+                    <span className="sr-only">PESOS</span>
                   </Link>
                 </SignedIn>
                 <SignedOut>
-                  <Link href="/">
-                    <h1 className="text-2xl font-bold text-gray-900 hover:text-gray-700 no-underline">
-                      PESOS
-                    </h1>
+                  <Link href="/" className="flex items-center">
+                    <PesosLogo className="w-8 h-8" />
+                    <span className="sr-only">PESOS</span>
                   </Link>
                 </SignedOut>
               </div>


### PR DESCRIPTION
## Summary
- add `PesosLogo` component with simple clock-themed logo
- replace text header with new logo
- document change in chronicler

## Testing
- `bun x next lint` *(fails: Cannot read config file)*
- `bun run test` *(fails: 8 test files failed)*

------
https://chatgpt.com/codex/tasks/task_e_684530cd6d94832ca10b77cf9cd0c0fd