### PR TITLE
Implement login-aware nav menu

### DIFF
--- a/chronicler.md
+++ b/chronicler.md
@@ -80,3 +80,8 @@ Appended a simple entry as requested.
 
 **Marked "fix codex" task complete.**
 Spent time ensuring Codex and Cursor's agents had everything necessary to be awesome.
+
+## 2025-06-08
+
+**Updated navigation for logged in users.**
+Added a `MenuNav` component and modified the header so About, Pricing, and Blog links collapse behind a Menu button when signed in. Logged out visitors still see the full nav.

--- a/components/MenuNav.tsx
+++ b/components/MenuNav.tsx
@@ -1,0 +1,38 @@
+"use client";
+import { useState } from "react";
+import Link from "next/link";
+
+export default function MenuNav() {
+  const [open, setOpen] = useState(false);
+  const navItems = [
+    { href: "/about", label: "About" },
+    { href: "/pricing", label: "Pricing" },
+    { href: "/blog", label: "Blog" },
+  ];
+
+  return (
+    <div className="relative">
+      <button
+        className="text-gray-600"
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+      >
+        Menu
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-40 bg-white border border-gray-200 rounded shadow-md flex flex-col">
+          {navItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="px-4 py-2 text-gray-600 hover:bg-gray-50"
+              onClick={() => setOpen(false)}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -6,7 +6,6 @@ import { Menu, X } from "lucide-react";
 export default function NavBar() {
   const [open, setOpen] = useState(false);
   const navItems = [
-    { href: "/", label: "Home" },
     { href: "/about", label: "About" },
     { href: "/pricing", label: "Pricing" },
     { href: "/blog", label: "Blog" },

--- a/components/root-layout-inner.tsx
+++ b/components/root-layout-inner.tsx
@@ -16,6 +16,7 @@ import UsernameModal from "./username-modal";
 import DBErrorScreen from "./db-error-screen";
 import { Settings, Download, Loader2 } from "lucide-react";
 import NavBar from "./NavBar";
+import MenuNav from "./MenuNav";
 import FeedEditor from "@/components/FeedEditor";
 
 interface FeedEntry {
@@ -256,7 +257,12 @@ export function RootLayoutInner({ children, inter }: RootLayoutInnerProps) {
                 </SignedOut>
               </div>
               <div className="flex items-center space-x-4">
-                <NavBar />
+                <SignedOut>
+                  <NavBar />
+                </SignedOut>
+                <SignedIn>
+                  <MenuNav />
+                </SignedIn>
                 <SignedIn>
                   {pathname !== "/dashboard/all_posts" && (
                     <>


### PR DESCRIPTION
## Summary
- add MenuNav dropdown for logged in users
- remove Home link from NavBar
- show MenuNav instead of full nav for authenticated users
- log the change in `chronicler`

## Testing
- `bun run lint` *(fails: Cannot read config file)*
- `bun run test` *(fails to resolve imports and React not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6845313a2964832cb5ddab36f400930e