### PR TITLE
Add onboarding wizard strategy

### DIFF
--- a/chronicler.md
+++ b/chronicler.md
@@ -80,3 +80,8 @@ Appended a simple entry as requested.
 
 **Marked "fix codex" task complete.**
 Spent time ensuring Codex and Cursor's agents had everything necessary to be awesome.
+
+## 2025-06-08
+
+**Outlined strategy for new user wizard and editing flow.**
+Created `docs/new-user-wizard.md` with a plan for a full-page multi-step setup wizard and inline editing pages. Updated `todo.md` with new tasks under "Onboarding & Editing" to track implementation work.

--- a/docs/new-user-wizard.md
+++ b/docs/new-user-wizard.md
@@ -1,0 +1,49 @@
+# New User Wizard & Editing Flow Strategy
+
+## Goals
+- Provide a mobile-friendly onboarding experience.
+- Allow returning users to edit sections without disruptive modals.
+- Keep the interface clean and in line with PESOS's calm, trustworthy vision.
+
+## Proposed Approach
+1. **Multi-Step Wizard Page**
+   - Instead of a modal, route new users to `/setup` after account creation.
+   - Each step occupies the full page with a progress indicator at the top.
+   - Steps:
+     1. Choose Username
+     2. Add Projects/Feeds
+     3. Confirm Schedule & Notifications
+     4. Setup Complete
+   - On mobile, each step stacks vertically with large touch targets.
+   - On desktop, optional sidebar shows upcoming steps.
+
+2. **Inline Editing for Existing Users**
+   - Replace modal feed editor with dedicated pages like `/settings/feeds`.
+   - Accessed via a sidebar or settings icon on the dashboard.
+   - Each section (Profile, Feeds, Notifications) is a page with forms that save instantly.
+   - Use drawers or expandable sections on mobile for compactness.
+
+3. **Persistent Sidebar Navigation**
+   - On wider screens, show a left sidebar with key sections:
+     - Dashboard
+     - Projects/Feeds
+     - Account Settings
+     - Data Export
+   - On mobile, collapse into a hamburger menu that slides over the content.
+
+4. **Getting Back to the Wizard**
+   - Progress is stored in localStorage or the database.
+   - Users can resume setup by visiting `/setup` at any time.
+   - Each step can be revisited to update information.
+
+5. **Visual Style**
+   - Minimal, airy design matching the rest of PESOS.
+   - Avoid heavy borders; use subtle shadows and clean typography.
+   - Animations should be calm and quick (e.g., fade transitions between steps).
+
+## Next Steps
+- Implement `/setup` route with step framework.
+- Migrate username and feed selection modals into wizard pages.
+- Create settings pages for feeds and profile management.
+- Update navigation to include sidebar on desktop and slide-out menu on mobile.
+

--- a/todo.md
+++ b/todo.md
@@ -65,6 +65,13 @@ A running list of tasks related to PESOS. May be edited by humans or agents.
   - [ ] Settings
   - [ ] Feed management
 
+### Onboarding & Editing
+
+- [ ] Replace modal-based onboarding with `/setup` wizard
+- [ ] Create dedicated settings pages for feeds and profile editing
+- [ ] Add sidebar navigation with mobile slide-out menu
+- [ ] Allow users to resume setup at any time
+
 ### Admin Features
 
 - [x] **Admin Monitoring Dashboard** - Build foundational admin interface


### PR DESCRIPTION
## Summary
- propose a mobile-friendly wizard and inline editing strategy
- document tasks to build the new onboarding flow
- log the design work in the chronicler

## Testing
- `bun test` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684531fed5f4832ca75735d04b8e41af