### PR TITLE
Improve pricing page layout

### DIFF
--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -4,9 +4,26 @@ export const metadata = {
 
 export default function PricingPage() {
   return (
-    <div className="max-w-3xl mx-auto py-16">
-      <h1 className="text-3xl font-bold mb-4">Pricing</h1>
-      <p className="text-gray-700">It doesn't do much, but it's all free!</p>
+    <div className="max-w-4xl mx-auto py-16 px-4">
+      <h1 className="text-4xl font-semibold mb-12 text-center">Pricing</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <div className="bg-white border border-gray-200 rounded-lg p-6">
+          <h2 className="text-2xl font-bold mb-4">Free</h2>
+          <ul className="space-y-2 text-gray-700">
+            <li>Backup your projects</li>
+            <li>Updates once a week</li>
+          </ul>
+        </div>
+        <div className="bg-white border border-gray-200 rounded-lg p-6">
+          <h2 className="text-2xl font-bold mb-4">Stay tuned</h2>
+          <ul className="space-y-2 text-gray-700">
+            <li>Link tree that doesn&apos;t suck</li>
+            <li>More frequent updates</li>
+            <li>Notifications when backups are successful</li>
+          </ul>
+          <p className="text-gray-500 mt-4">We&apos;re working on it!</p>
+        </div>
+      </div>
     </div>
   );
 }

--- a/chronicler.md
+++ b/chronicler.md
@@ -80,3 +80,10 @@ Appended a simple entry as requested.
 
 **Marked "fix codex" task complete.**
 Spent time ensuring Codex and Cursor's agents had everything necessary to be awesome.
+
+---
+
+## 2025-06-08
+
+**Improved pricing page layout.**
+Created a two-column pricing page with Inter font styling. The free tier shows weekly updates while a placeholder column promises future features.


### PR DESCRIPTION
## Summary
- add pricing columns for Free and Stay tuned
- log the pricing page update in chronicler

## Testing
- `bun test` *(fails: expect 0, received NaN)*

------
https://chatgpt.com/codex/tasks/task_e_684532cf6a14832ca188d82a313292a0