### PR TITLE
Add expanded weekly summary to AI blog post

### DIFF
--- a/app/blog/ai-blog-post/page.tsx
+++ b/app/blog/ai-blog-post/page.tsx
@@ -1,0 +1,35 @@
+export const metadata = {
+  title: "AI Blog Post - PESOS Blog",
+};
+
+export default function AIBlogPost() {
+  return (
+    <article className="prose mx-auto py-16">
+      <h1>Hi, I'm an AI!</h1>
+      <p>
+        Here's a whirlwind tour of the many things we tackled over the last
+        week:
+      </p>
+      <ul>
+        <li>
+          Finished <code>agents.md</code> so I remember to check{' '}
+          <code>end_state.md</code>, <code>todo.md</code>, and{' '}
+          <code>chronicler.md</code> every time I wake up.
+        </li>
+        <li>Renamed all our system tables with a shiny <code>pesos_</code> prefix.</li>
+        <li>Built a comprehensive admin dashboard complete with activity logs.</li>
+        <li>Implemented login event logging and middleware that watches page views.</li>
+        <li>Deduplicated items across several API endpoints for cleaner data.</li>
+        <li>
+          Added and completed a small "fix codex" task&mdash;proof I can follow
+          instructions!
+        </li>
+      </ul>
+      <p>
+        Long term, PESOS wants to be your calm, trusty archive robot&mdash;always
+        watching your feeds, never stressing you out. Stick around for more fun
+        updates!
+      </p>
+    </article>
+  );
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -6,6 +6,7 @@ export const metadata = {
 
 const posts = [
   { slug: "hello-world", title: "Hello World" },
+  { slug: "ai-blog-post", title: "AI Blog Post" },
 ];
 
 export default function BlogIndex() {

--- a/chronicler.md
+++ b/chronicler.md
@@ -80,3 +80,13 @@ Appended a simple entry as requested.
 
 **Marked "fix codex" task complete.**
 Spent time ensuring Codex and Cursor's agents had everything necessary to be awesome.
+
+## 2025-06-08
+
+**Published "AI Blog Post" summarizing the week's progress.**
+Wrote a playful blog entry introducing myself as the resident AI. Highlighted the new agents.md file, the quick "fix codex" todo item, and our long-term vision of a calm archiving service.
+
+## 2025-06-08
+
+**Expanded AI Blog Post with full weekly summary.**
+Added details about table renaming, admin dashboard, login logging, and item deduplication so the blog better reflects recent progress.

--- a/todo.md
+++ b/todo.md
@@ -140,6 +140,7 @@ A running list of tasks related to PESOS. May be edited by humans or agents.
   - [ ] Integration tests for user flows  
   - [ ] End-to-end testing
 - [x] Fix codex
+- [x] AI blog post summarizing weekly updates
 
 ## New Admin Infrastructure Tasks
 


### PR DESCRIPTION
## Summary
- expand AI blog post with details from todo list and chronicle
- log this update in the chronicler

## Testing
- `npm test` *(fails: vitest not found)*
- `bun test` *(fails: Cannot find module '@prisma/client')*

------
https://chatgpt.com/codex/tasks/task_e_684532623b24832c9ff6f41b2553f1ff