### PR TITLE
Fix menu layering issue

### DIFF
--- a/components/root-layout-inner.tsx
+++ b/components/root-layout-inner.tsx
@@ -238,7 +238,7 @@ export function RootLayoutInner({ children, inter }: RootLayoutInnerProps) {
       }`}
     >
       {!hideHeader && (
-        <header className="bg-white shadow-sm">
+        <header className="relative z-10 bg-white shadow-sm">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
             <div className="flex justify-between items-center">
               <div>


### PR DESCRIPTION
## Summary
- ensure header sits above page background

## Testing
- `bun test` *(fails: Cannot find package 'clsx', Cannot find module '@prisma/client', Cannot find module 'next/server', Cannot find module 'react/jsx-dev-runtime')*

------
https://chatgpt.com/codex/tasks/task_e_6846656ff7f4832c8b0a39e7a241e890