### PR TITLE
Implement basic logging dashboard

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -1,0 +1,48 @@
+import useSWR from "swr";
+
+export const dynamic = "force-dynamic";
+
+interface LogEntry {
+  id: number;
+  eventType: string;
+  message: string;
+  userId?: string | null;
+  createdAt: string;
+}
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export default function AdminDashboard() {
+  const { data, error } = useSWR<{ logs: LogEntry[] }>("/api/admin/logs", fetcher);
+
+  if (error) return <div>Error loading logs</div>;
+  if (!data) return <div>Loading...</div>;
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">System Logs</h1>
+      <table className="min-w-full text-sm text-left text-gray-300">
+        <thead className="border-b border-gray-700">
+          <tr>
+            <th className="px-2 py-1">Time</th>
+            <th className="px-2 py-1">Event</th>
+            <th className="px-2 py-1">User</th>
+            <th className="px-2 py-1">Message</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.logs.map((log) => (
+            <tr key={log.id} className="border-b border-gray-800">
+              <td className="px-2 py-1">
+                {new Date(log.createdAt).toLocaleString()}
+              </td>
+              <td className="px-2 py-1">{log.eventType}</td>
+              <td className="px-2 py-1">{log.userId || "-"}</td>
+              <td className="px-2 py-1">{log.message}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/api/admin/logs/route.ts
+++ b/app/api/admin/logs/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prismadb";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const logs = await prisma.systemLog.findMany({
+    orderBy: { createdAt: "desc" },
+    take: 100,
+  });
+  return NextResponse.json({ logs });
+}

--- a/app/api/backup/route.ts
+++ b/app/api/backup/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { logEvent } from "@/lib/log";
 
 export const dynamic = "force-dynamic";
 
@@ -193,6 +194,12 @@ export async function POST(request: Request) {
         global.backupStatus.status = "completed";
       }
 
+      await logEvent(
+        "system_update",
+        `Backup completed with ${totalNewItems} new items",
+        userId
+      );
+
       return NextResponse.json({
         status: "completed",
         storyCount: totalNewItems,
@@ -206,6 +213,11 @@ export async function POST(request: Request) {
           global.backupStatus.lastError = error.message;
         }
       }
+      await logEvent(
+        "system_update",
+        `Backup failed: ${error instanceof Error ? error.message : "unknown"}`,
+        userId
+      );
       throw error;
     }
   } catch (error) {

--- a/app/api/createUser/route.ts
+++ b/app/api/createUser/route.ts
@@ -4,6 +4,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { NextRequest } from "next/server";
+import { logEvent } from "@/lib/log";
 
 export const dynamic = "force-dynamic";
 
@@ -71,6 +72,8 @@ export async function POST(request: Request) {
         username: username.toLowerCase(),
       },
     });
+
+    await logEvent("new_user", `User ${username} created`, clerkId);
 
     return NextResponse.json({
       success: true,

--- a/app/api/log-login/route.ts
+++ b/app/api/log-login/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs";
+import { logEvent } from "@/lib/log";
+
+export const dynamic = "force-dynamic";
+
+export async function POST() {
+  const { userId } = auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  await logEvent("login", "User logged in", userId);
+  return NextResponse.json({ success: true });
+}

--- a/app/dashboard/all_posts/page.tsx
+++ b/app/dashboard/all_posts/page.tsx
@@ -48,6 +48,10 @@ export default function StatsPage() {
   const [disabledSources, setDisabledSources] = useState<string[]>([]);
 
   useEffect(() => {
+    fetch("/api/log-login", { method: "POST" });
+  }, []);
+
+  useEffect(() => {
     if (searchParams) {
       const page = searchParams.get("page");
       if (page) {

--- a/app/dashboard/simple/page.tsx
+++ b/app/dashboard/simple/page.tsx
@@ -74,6 +74,10 @@ export default function SimpleDashboard() {
   });
 
   useEffect(() => {
+    fetch("/api/log-login", { method: "POST" });
+  }, []);
+
+  useEffect(() => {
     if (sourcesData?.hasDisabledSources) {
       setHasDisabledSources(true);
       if (sourcesData.disabledSources) {

--- a/chronicler.md
+++ b/chronicler.md
@@ -38,3 +38,17 @@ Appended a simple entry as requested.
 
 **Marked "fix codex" task complete.**
 Spent time ensuring Codex and Cursor's agents had everything necessary to be awesome.
+
+---
+
+## 2025-06-08
+
+**Implemented basic logging system and admin dashboard.**
+Added `SystemLog` model, logging utilities, and new routes to record logins, new users, and backups. Created `/admin/dashboard` to view logs.
+
+---
+
+## 2025-06-09
+
+**Added system logging dashboard and route.**
+Integrated `SystemLog` model with Prisma and created admin log display and login tracking. Tests still failing due to missing modules.

--- a/lib/__tests__/test-utils.ts
+++ b/lib/__tests__/test-utils.ts
@@ -41,6 +41,10 @@ export const createMockPrisma = () => {
       create: vi.fn(),
       findMany: vi.fn(),
     },
+    SystemLog: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+    },
   };
 };
 

--- a/lib/log.ts
+++ b/lib/log.ts
@@ -1,0 +1,15 @@
+import prisma from "@/lib/prismadb";
+
+export async function logEvent(eventType: string, message: string, userId?: string) {
+  try {
+    await prisma.systemLog.create({
+      data: {
+        eventType,
+        message,
+        userId: userId || null,
+      },
+    });
+  } catch (error) {
+    console.error("[logEvent] Failed to write log", error);
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -97,3 +97,11 @@ model SystemStatus {
   processedFeeds  Int       @default(0)
   executionTimeMs Int       @default(0)
 }
+
+model SystemLog {
+  id        Int      @id @default(autoincrement())
+  eventType String
+  message   String
+  userId    String?
+  createdAt DateTime @default(now())
+}

--- a/todo.md
+++ b/todo.md
@@ -71,7 +71,7 @@ A running list of tasks related to PESOS. May be edited by humans or agents.
   - [ ] Basic user stats
   - [ ] Processing queue visibility
   - [ ] Error log viewing (verbose/diagnosable)
-- [ ] Logging system
+- [x] Logging system
   - [ ] Backup logs
   - [ ] Queue logs
   - [ ] Error tracking


### PR DESCRIPTION
## Summary
- add `SystemLog` model to schema for event tracking
- log new user creation, backups, and user logins
- expose logs via `/api/admin/logs` and view at `/admin/dashboard`
- create `logEvent` utility for writing to the log table
- update todo and chronicler

## Testing
- `bun test` *(fails: Cannot find package 'clsx', cannot find module 'next/server')*
- `bun x prisma migrate dev --name add-system-log` *(fails: 403 Forbidden retrieving engines)*

------
https://chatgpt.com/codex/tasks/task_e_68450fb0c5cc832ca899f62e81f36be2