### PR TITLE
Blog post on end-state file and remove manual fetch

### DIFF
--- a/app/blog/end-state-file/page.tsx
+++ b/app/blog/end-state-file/page.tsx
@@ -1,0 +1,47 @@
+export const metadata = {
+  title: "Checking the End State - PESOS Blog",
+};
+
+export default function EndStateFilePost() {
+  return (
+    <article className="prose mx-auto py-16">
+      <h1>Working Backwards from the End State</h1>
+      <p>
+        Over the last few days we've been leaning heavily on a simple trio of
+        files: <code>end_state.md</code>, <code>todo.md</code> and
+        <code>chronicler.md</code>. Together they keep development focused and
+        provide a running memory of what changed.
+      </p>
+      <p>
+        The <code>end_state.md</code> file lays out the vision&mdash;a calm,
+        trustworthy archiving robot. Before touching code we read it to make sure
+        every task lines up with that goal.
+      </p>
+      <p>
+        From there <code>todo.md</code> gives us bite‑sized tasks. Recent
+        examples include pruning manual sync buttons and polishing the admin
+        dashboard.
+      </p>
+      <p>
+        Each time a task is tackled we jot a quick note in
+        <code>chronicler.md</code>. It's our lightweight changelog and helps the
+        next agent know exactly what happened. Skimming it shows the move to
+        server‑side admin pages, new logging hooks, and a steady march toward
+        that calm confidence vibe.
+      </p>
+      <h2>Why it Works</h2>
+      <p>
+        This loop of vision → tasks → log keeps the project grounded. Every
+        action ties back to the end state, while the chronicle provides context
+        and momentum. It's low friction but surprisingly powerful.
+      </p>
+      <h2>How We Could Improve</h2>
+      <p>
+        The naming could be clearer. <code>chronicler.md</code> is fun but maybe
+        <code>progress_log.md</code> or similar would be more obvious. Automated
+        summaries or linking entries to pull requests would help too.
+      </p>
+      <p>Iterating on the process itself is part of the journey.</p>
+    </article>
+  );
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -7,6 +7,7 @@ export const metadata = {
 const posts = [
   { slug: "hello-world", title: "Hello World" },
   { slug: "ai-blog-post", title: "AI Blog Post" },
+  { slug: "end-state-file", title: "Checking the End State" },
 ];
 
 export default function BlogIndex() {

--- a/app/dashboard/all_posts/page.tsx
+++ b/app/dashboard/all_posts/page.tsx
@@ -10,7 +10,6 @@ import { DataTable } from "@/components/data-table";
 import ActivityChart from "@/components/ActivityChart";
 import FeedEditor, { FeedEntry } from "@/components/FeedEditor";
 import { Button } from "@/components/ui/button";
-import UpdateFeedsButton from "@/components/UpdateFeedsButton";
 import { Settings, Download } from "lucide-react";
 import Link from "next/link";
 import DisabledFeedsBanner from "@/components/DisabledFeedsBanner";
@@ -43,7 +42,6 @@ export default function StatsPage() {
   const [showFeedEditor, setShowFeedEditor] = useState(false);
   const [feeds, setFeeds] = useState<FeedEntry[]>([]);
   const [feedEditorError, setFeedEditorError] = useState<string | null>(null);
-  const showManualUpdate = searchParams?.get("manual") === "true";
   const [hasDisabledSources, setHasDisabledSources] = useState(false);
   const [disabledSources, setDisabledSources] = useState<string[]>([]);
 
@@ -222,7 +220,6 @@ export default function StatsPage() {
           >
             Switch to simple mode
           </Link>
-          {showManualUpdate && <UpdateFeedsButton />}
         </div>
       </div>
 

--- a/chronicler.md
+++ b/chronicler.md
@@ -195,3 +195,8 @@ Logged operations in add-pesos-source, sources, and blocked-feeds routes for adm
 ## 2025-06-09
 
 **Simplified admin dashboard.** Replaced the bulky dashboard page with a lightweight version that fetches the latest activity logs from /api/admin/logs. This makes it easy to verify logging is working.
+
+## 2025-06-10
+
+**Removed manual sync buttons and added end state blog post.**
+Pruned the manual "Sync All Feeds" buttons from the dashboard to reinforce the automatic nature of backups. Added a new blog entry explaining how `end_state.md`, `todo.md`, and `chronicler.md` guide development and suggested renaming the chronicle for clarity.

--- a/todo.md
+++ b/todo.md
@@ -47,7 +47,7 @@ A running list of tasks related to PESOS. May be edited by humans or agents.
   - [ ] Queue status display ("5 items queued, processing in 2 hours")
   - [ ] Last backup timestamp with friendly language
   - [ ] System health indicators
-  - [ ] Remove manual fetch buttons (per end state requirements)
+  - [x] Remove manual fetch buttons (per end state requirements)
   - [x] Immediate loading spinner for `/dashboard/simple`
 
 - [ ] **Data Export Enhancement** - Polish existing export functionality


### PR DESCRIPTION
## Summary
- add blog post describing end_state, todo, and chronicler workflow
- list post on blog index
- remove manual sync buttons from dashboard pages
- mark todo item done and log changes in chronicler

## Testing
- `npm test` *(fails: Failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_68488558b8e8832c8165549d8d3430b8