### PR TITLE
Enhance admin dashboard and pricing page

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -1,10 +1,11 @@
-import prisma from "@/lib/prismadb";
+"use client";
 
-export const dynamic = "force-dynamic";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
 
 interface LogEntry {
   id: number;
-  timestamp: Date;
+  timestamp: string;
   eventType: string;
   userId?: string | null;
   metadata?: any;
@@ -16,52 +17,84 @@ interface LogEntry {
   source?: string | null;
 }
 
-async function getLogs(): Promise<LogEntry[]> {
-  const logs = await prisma.activityLog.findMany({
-    orderBy: { timestamp: "desc" },
-    take: 100,
-  });
-  return logs;
+interface Stats {
+  newUsers: number;
+  totalLogins: number;
+  errorCount: number;
+  systemUpdates: number;
+  period: string;
 }
 
-export default async function AdminDashboard() {
-  const logs = await getLogs();
+export default function AdminDashboard() {
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchLogs = async () => {
+    setLoading(true);
+    const res = await fetch("/api/admin/activity-logs");
+    const data = await res.json();
+    setLogs(data.logs);
+    setStats(data.stats);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchLogs();
+    const id = setInterval(fetchLogs, 30000);
+    return () => clearInterval(id);
+  }, []);
 
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">System Logs</h1>
-      <table className="min-w-full text-sm text-left text-gray-800">
-        <thead className="border-b border-gray-200">
-          <tr>
-            <th className="px-2 py-1">Time</th>
-            <th className="px-2 py-1">Event</th>
-            <th className="px-2 py-1">User</th>
-            <th className="px-2 py-1">Success</th>
-            <th className="px-2 py-1">Source</th>
-            <th className="px-2 py-1">Metadata</th>
-          </tr>
-        </thead>
-        <tbody>
-          {logs.map((log) => (
-            <tr key={log.id} className="border-b border-gray-100">
-              <td className="px-2 py-1">
-                {new Date(log.timestamp).toLocaleString()}
-              </td>
-              <td className="px-2 py-1">{log.eventType}</td>
-              <td className="px-2 py-1">{log.userId || "-"}</td>
-              <td className="px-2 py-1">
-                <span className={log.success ? "text-green-600" : "text-red-600"}>
-                  {log.success ? "✓" : "✗"}
-                </span>
-              </td>
-              <td className="px-2 py-1">{log.source || "-"}</td>
-              <td className="px-2 py-1">
-                {log.metadata ? JSON.stringify(log.metadata) : "-"}
-              </td>
+      {stats && (
+        <div className="flex space-x-4 mb-4 text-sm text-gray-700">
+          <span>New Users: {stats.newUsers}</span>
+          <span>Logins: {stats.totalLogins}</span>
+          <span>Updates: {stats.systemUpdates}</span>
+          <span className="text-red-600">Errors: {stats.errorCount}</span>
+        </div>
+      )}
+      <Button onClick={fetchLogs} className="mb-4" size="sm">
+        Refresh
+      </Button>
+      {loading ? (
+        <div>Loading...</div>
+      ) : (
+        <table className="min-w-full text-sm text-left text-gray-800">
+          <thead className="border-b border-gray-200">
+            <tr>
+              <th className="px-2 py-1">Time</th>
+              <th className="px-2 py-1">Event</th>
+              <th className="px-2 py-1">User</th>
+              <th className="px-2 py-1">Success</th>
+              <th className="px-2 py-1">Source</th>
+              <th className="px-2 py-1">Metadata</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {logs.map((log) => (
+              <tr key={log.id} className="border-b border-gray-100">
+                <td className="px-2 py-1">
+                  {new Date(log.timestamp).toLocaleString()}
+                </td>
+                <td className="px-2 py-1">{log.eventType}</td>
+                <td className="px-2 py-1">{log.userId || "-"}</td>
+                <td className="px-2 py-1">
+                  <span className={log.success ? "text-green-600" : "text-red-600"}>
+                    {log.success ? "✓" : "✗"}
+                  </span>
+                </td>
+                <td className="px-2 py-1">{log.source || "-"}</td>
+                <td className="px-2 py-1">
+                  {log.metadata ? JSON.stringify(log.metadata) : "-"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -2,47 +2,55 @@ export const metadata = {
   title: "Pricing - PESOS",
 };
 
+import PricingCard from "@/components/PricingCard";
+import Link from "next/link";
+
 export default function PricingPage() {
   return (
-    <div className="max-w-4xl mx-auto py-16 px-4">
+    <div className="max-w-5xl mx-auto py-16 px-4">
       <h1 className="text-4xl font-semibold mb-12 text-center">Pricing</h1>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-        <div className="bg-white border border-gray-200 rounded-lg p-6">
-          <h2 className="text-2xl font-bold mb-4">Free</h2>
-          <ul className="space-y-2 text-gray-700">
-            <li>Automatic weekly backups</li>
-            <li>Simple status dashboard</li>
-            <li>Export your data anytime</li>
-            <li>Community support</li>
-          </ul>
-          <p className="text-gray-500 mt-4">Perfect for personal archiving.</p>
-        </div>
-        <div className="bg-white border border-gray-200 rounded-lg p-6">
-          <h2 className="text-2xl font-bold mb-4">Pro &ndash; Coming Soon</h2>
-          <ul className="space-y-2 text-gray-700">
-            <li>Beautiful link pages that replace LinkTree</li>
-            <li>Daily backups and priority processing</li>
-            <li>Email notifications for every backup</li>
-            <li>Usage analytics</li>
-            <li>Priority support</li>
-          </ul>
-          <p className="text-gray-500 mt-4">
-            $5/month once billing is enabled. Join the early access list below.
-            Hosted pages and magazine access included.
-          </p>
-        </div>
+        <PricingCard
+          title="Free"
+          price="$0"
+          features={[
+            "Automatic weekly backups",
+            "Simple status dashboard",
+            "Export your data anytime",
+            "Community support",
+          ]}
+        />
+        <PricingCard
+          title="Pro – Coming Soon"
+          price="$5/mo"
+          highlight
+          features={[
+            "Beautiful link pages",
+            "Daily backups, priority processing",
+            "Email notifications",
+            "Usage analytics",
+            "Priority support",
+          ]}
+          cta={
+            <Link href="/subscribe" className="w-full">
+              <button className="w-full bg-blue-600 text-white py-2 rounded-md">
+                Join Waitlist
+              </button>
+            </Link>
+          }
+        />
       </div>
       <p className="text-center mt-12">
         Want updates when Pro launches?{' '}
-        <a href="/subscribe" className="text-blue-600 underline">
+        <Link href="/subscribe" className="text-blue-600 underline">
           Sign up for email notifications
-        </a>
+        </Link>
         .
       </p>
       <p className="text-center mt-4 text-sm text-gray-600">
         Preview upcoming features on the{' '}
-        <a href="/link/demo" className="underline">link page demo</a> and the{' '}
-        <a href="/magazine" className="underline">magazine</a>.
+        <Link href="/link/demo" className="underline">link page demo</Link> and the{' '}
+        <Link href="/magazine" className="underline">magazine</Link>.
       </p>
     </div>
   );

--- a/chronicler.md
+++ b/chronicler.md
@@ -252,3 +252,11 @@ Implemented a basic multi-step setup flow with `/setup/username`, `/setup/feeds`
 
 **Fixed Prisma schema relation for LinkPage.**
 Added missing `linkPages` relation on `pesos_User` so Prisma can generate client successfully. This resolves schema validation error in build step.
+
+## 2025-06-15
+
+**Enhanced admin dashboard and pricing page.**
+- Rebuilt `/admin/dashboard` as a client component that fetches logs from the API with automatic refresh.
+- Display summary stats and a manual refresh button for better monitoring.
+- Added reusable `PricingCard` component and redesigned `/pricing` with a highlighted Pro plan and clear call to action.
+- Marked real-time refresh task complete in `todo.md`.

--- a/components/PricingCard.tsx
+++ b/components/PricingCard.tsx
@@ -1,0 +1,33 @@
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+interface PricingCardProps {
+  title: string;
+  price?: string;
+  features: string[];
+  highlight?: boolean;
+  cta?: React.ReactNode;
+}
+
+export default function PricingCard({ title, price, features, highlight, cta }: PricingCardProps) {
+  return (
+    <Card
+      className={highlight ? "border-blue-500 shadow-lg" : "border-gray-200"}
+    >
+      <CardHeader>
+        <CardTitle className="text-2xl font-bold">
+          {title}
+        </CardTitle>
+        {price && <div className="text-gray-500 mt-1">{price}</div>}
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-2 text-sm text-gray-700">
+          {features.map((f) => (
+            <li key={f}>{f}</li>
+          ))}
+        </ul>
+      </CardContent>
+      {cta && <CardFooter>{cta}</CardFooter>}
+    </Card>
+  );
+}

--- a/todo.md
+++ b/todo.md
@@ -166,7 +166,7 @@ A running list of tasks related to PESOS. May be edited by humans or agents.
   - [x] Add logging to backup creation
 
 - [ ] **Admin Dashboard Enhancements**
-  - [ ] Add real-time refresh capability
+  - [x] Add real-time refresh capability
   - [ ] Add data export from admin dashboard
   - [ ] Add user lookup and management features
   - [ ] Add system health monitoring alerts


### PR DESCRIPTION
## Summary
- add `<PricingCard>` component for consistent pricing layout
- redesign pricing page with highlighted Pro tier
- rebuild admin dashboard as client component fetching logs via API
- show summary stats and auto-refresh logs
- document progress in chronicler and mark todo item complete

## Testing
- `bun test` *(fails: Cannot find module '@prisma/client')*

------
https://chatgpt.com/codex/tasks/task_e_684a9b899aa4832cb9d860b41db6b407