### PR TITLE
Simplify Pro plan card

### DIFF
--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -22,22 +22,8 @@ export default function PricingPage() {
         />
         <PricingCard
           title="Pro – Coming Soon"
-          price="$5/mo"
           highlight
-          features={[
-            "Beautiful link pages",
-            "Daily backups, priority processing",
-            "Email notifications",
-            "Usage analytics",
-            "Priority support",
-          ]}
-          cta={
-            <Link href="/subscribe" className="w-full">
-              <button className="w-full bg-blue-600 text-white py-2 rounded-md">
-                Join Waitlist
-              </button>
-            </Link>
-          }
+          features={["Coming soon!"]}
         />
       </div>
       <p className="text-center mt-12">

--- a/chronicler.md
+++ b/chronicler.md
@@ -260,3 +260,8 @@ Added missing `linkPages` relation on `pesos_User` so Prisma can generate client
 - Display summary stats and a manual refresh button for better monitoring.
 - Added reusable `PricingCard` component and redesigned `/pricing` with a highlighted Pro plan and clear call to action.
 - Marked real-time refresh task complete in `todo.md`.
+
+## 2025-06-16
+
+**Simplified Pro pricing section.**
+Updated `/pricing` page so the Pro card only shows "Coming soon!" instead of a full feature list and pricing.


### PR DESCRIPTION
## Summary
- streamline the Pro section on the pricing page
- log change in chronicler

## Testing
- `bun test` *(fails: Cannot find package 'clsx' and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_684aa0b5fab4832c895618f2bf3967cb