### PR TITLE
Improve admin dashboard UI

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
+import AdminStats from "@/components/AdminStats";
 
 interface LogEntry {
   id: number;
@@ -46,54 +47,51 @@ export default function AdminDashboard() {
   }, []);
 
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">System Logs</h1>
-      {stats && (
-        <div className="flex space-x-4 mb-4 text-sm text-gray-700">
-          <span>New Users: {stats.newUsers}</span>
-          <span>Logins: {stats.totalLogins}</span>
-          <span>Updates: {stats.systemUpdates}</span>
-          <span className="text-red-600">Errors: {stats.errorCount}</span>
-        </div>
-      )}
-      <Button onClick={fetchLogs} className="mb-4" size="sm">
-        Refresh
-      </Button>
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 via-gray-100 to-gray-200 p-6">
+      <h1 className="mb-8 text-center text-3xl font-bold">Admin Dashboard</h1>
+      {stats && <AdminStats stats={stats} />}
+      <div className="mb-4 text-right">
+        <Button onClick={fetchLogs} size="sm">
+          Refresh
+        </Button>
+      </div>
       {loading ? (
         <div>Loading...</div>
       ) : (
-        <table className="min-w-full text-sm text-left text-gray-800">
-          <thead className="border-b border-gray-200">
-            <tr>
-              <th className="px-2 py-1">Time</th>
-              <th className="px-2 py-1">Event</th>
-              <th className="px-2 py-1">User</th>
-              <th className="px-2 py-1">Success</th>
-              <th className="px-2 py-1">Source</th>
-              <th className="px-2 py-1">Metadata</th>
-            </tr>
-          </thead>
-          <tbody>
-            {logs.map((log) => (
-              <tr key={log.id} className="border-b border-gray-100">
-                <td className="px-2 py-1">
-                  {new Date(log.timestamp).toLocaleString()}
-                </td>
-                <td className="px-2 py-1">{log.eventType}</td>
-                <td className="px-2 py-1">{log.userId || "-"}</td>
-                <td className="px-2 py-1">
-                  <span className={log.success ? "text-green-600" : "text-red-600"}>
-                    {log.success ? "✓" : "✗"}
-                  </span>
-                </td>
-                <td className="px-2 py-1">{log.source || "-"}</td>
-                <td className="px-2 py-1">
-                  {log.metadata ? JSON.stringify(log.metadata) : "-"}
-                </td>
+        <div className="overflow-auto rounded-xl bg-white shadow">
+          <table className="min-w-full text-sm text-gray-800">
+            <thead className="sticky top-0 bg-gray-50 text-left text-xs uppercase tracking-wide">
+              <tr>
+                <th className="px-3 py-2">Time</th>
+                <th className="px-3 py-2">Event</th>
+                <th className="px-3 py-2">User</th>
+                <th className="px-3 py-2">Success</th>
+                <th className="px-3 py-2">Source</th>
+                <th className="px-3 py-2">Metadata</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {logs.map((log) => (
+                <tr key={log.id} className="border-t">
+                  <td className="px-3 py-2">
+                    {new Date(log.timestamp).toLocaleString()}
+                  </td>
+                  <td className="px-3 py-2">{log.eventType}</td>
+                  <td className="px-3 py-2">{log.userId || "-"}</td>
+                  <td className="px-3 py-2">
+                    <span className={log.success ? "text-green-600" : "text-red-600"}>
+                      {log.success ? "✓" : "✗"}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2">{log.source || "-"}</td>
+                  <td className="px-3 py-2 text-xs">
+                    {log.metadata ? JSON.stringify(log.metadata) : "-"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );

--- a/chronicler.md
+++ b/chronicler.md
@@ -260,3 +260,10 @@ Added missing `linkPages` relation on `pesos_User` so Prisma can generate client
 - Display summary stats and a manual refresh button for better monitoring.
 - Added reusable `PricingCard` component and redesigned `/pricing` with a highlighted Pro plan and clear call to action.
 - Marked real-time refresh task complete in `todo.md`.
+
+## 2025-06-16
+
+**Polished admin dashboard UI.**
+- Added `AdminStats` component with clean cards for key metrics.
+- Redesigned `/admin/dashboard` with gradient background and styled log table.
+- Marked design improvement task complete in `todo.md`.

--- a/components/AdminStats.tsx
+++ b/components/AdminStats.tsx
@@ -1,0 +1,40 @@
+import { Users, LogIn, RefreshCcw, AlertCircle } from "lucide-react";
+
+interface Stats {
+  newUsers: number;
+  totalLogins: number;
+  errorCount: number;
+  systemUpdates: number;
+  period: string;
+}
+
+export default function AdminStats({ stats }: { stats: Stats }) {
+  const items = [
+    { label: "New Users", value: stats.newUsers, Icon: Users },
+    { label: "Logins", value: stats.totalLogins, Icon: LogIn },
+    { label: "Updates", value: stats.systemUpdates, Icon: RefreshCcw },
+    { label: "Errors", value: stats.errorCount, Icon: AlertCircle },
+  ];
+
+  return (
+    <div className="mb-8">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {items.map(({ label, value, Icon }) => (
+          <div
+            key={label}
+            className="flex flex-col items-center rounded-xl bg-white/70 backdrop-blur-md p-4 shadow"
+          >
+            <Icon className="mb-2 h-5 w-5 text-gray-600" />
+            <div className="text-2xl font-semibold text-gray-800">{value}</div>
+            <div className="text-xs uppercase tracking-wide text-gray-500">
+              {label}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-2 text-center text-xs text-gray-600">
+        {stats.period}
+      </div>
+    </div>
+  );
+}

--- a/todo.md
+++ b/todo.md
@@ -167,6 +167,7 @@ A running list of tasks related to PESOS. May be edited by humans or agents.
 
 - [ ] **Admin Dashboard Enhancements**
   - [x] Add real-time refresh capability
+  - [x] Apply polished design with stats cards
   - [ ] Add data export from admin dashboard
   - [ ] Add user lookup and management features
   - [ ] Add system health monitoring alerts


### PR DESCRIPTION
## Summary
- add `AdminStats` component for simple stat cards
- redesign `/admin/dashboard` with gradient background, stat cards, and tidy log table
- record dashboard design task in todo and chronicler

## Testing
- `./node_modules/.bin/vitest` *(fails: Failed to resolve import; environment lacks prisma setup)*

------
https://chatgpt.com/codex/tasks/task_e_684aa1778894832c8d25172db308f54e