### PR TITLE
Adjust tagline width on landing page

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -304,3 +304,10 @@ Updated `/pricing` page so the Pro card only shows "Coming soon!" instead of a f
 
 **Renamed chronicler to changelog and removed old favicon.**
 Updated references across docs and code, deleted `app/favicon.ico`, and adjusted logo color. Tests failing due to missing modules.
+
+## 2025-06-20
+
+**Narrowed landing page tagline width.**
+Reduced the heading container to `max-w-lg` on the home screen so the text
+"You should back up your projects once a week, and that's all PESOS does."
+does not stretch too wide.

--- a/components/LandingPageWithUsername.tsx
+++ b/components/LandingPageWithUsername.tsx
@@ -186,7 +186,7 @@ export default function LandingPageWithUsername() {
         <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-20 lg:py-8">
           <div className="flex flex-col items-center justify-center text-center">
             {/* Main heading */}
-            <div className="max-w-2xl mb-12">
+            <div className="max-w-lg mb-12 mx-auto">
               <h1
                 className="text-2xl sm:text-3xl lg:text-4xl font-normal text-black mb-6 leading-tight"
                 style={{ fontFamily: "'Instrument Serif', serif" }}


### PR DESCRIPTION
## Summary
- limit landing page tagline to `max-w-lg`
- document the change

## Testing
- `bun test` *(fails: @prisma/client did not initialize)*

------
https://chatgpt.com/codex/tasks/task_e_68550a192a0c832ca0d1b9c2896ce9f7