### PR TITLE
Fix prolific sources dashboard crash

### DIFF
--- a/app/dashboard/prolific-sources/page.tsx
+++ b/app/dashboard/prolific-sources/page.tsx
@@ -7,12 +7,12 @@ interface ProlificSource {
   id: number;
   url: string;
   active: string;
-  itemCount: number;
-  userCount: number;
-  oldestPost: string | null;
-  newestPost: string | null;
-  avgHoursBetweenPosts: string | null;
-  postsPerDay: string | null;
+  itemCount?: number;
+  userCount?: number;
+  oldestPost?: string | null;
+  newestPost?: string | null;
+  avgHoursBetweenPosts?: string | null;
+  postsPerDay?: string | null;
 }
 
 export default function ProlificSourcesPage() {
@@ -44,7 +44,8 @@ export default function ProlificSourcesPage() {
         }
         
         const data = await response.json();
-        setSources(data.prolificSources);
+        const result = data.prolificSources || data.sources || [];
+        setSources(Array.isArray(result) ? result : []);
         // Always set isAdmin to true since we've removed the admin check
         setIsAdmin(true);
         setLoading(false);

--- a/changelog.md
+++ b/changelog.md
@@ -304,3 +304,8 @@ Updated `/pricing` page so the Pro card only shows "Coming soon!" instead of a f
 
 **Renamed chronicler to changelog and removed old favicon.**
 Updated references across docs and code, deleted `app/favicon.ico`, and adjusted logo color. Tests failing due to missing modules.
+
+## 2025-06-20
+
+**Fixed prolific sources page.**
+Updated client page to handle API response with `sources` key and made stats fields optional to prevent crashes.

--- a/todo.md
+++ b/todo.md
@@ -172,3 +172,4 @@ A running list of tasks related to PESOS. May be edited by humans or agents.
   - [ ] Add data export from admin dashboard
   - [ ] Add user lookup and management features
   - [ ] Add system health monitoring alerts
+  - [x] Fix crash on `/dashboard/prolific-sources` when API returns `sources` key


### PR DESCRIPTION
## Summary
- fix API data mapping on `/dashboard/prolific-sources`
- mark properties optional
- document fix in changelog and todo

## Testing
- `bun run test` *(fails: Failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_68550b4d9e68832c980864d92f97346d