### PR TITLE
Implement view preference storage

### DIFF
--- a/app/api/set-view-preference/route.ts
+++ b/app/api/set-view-preference/route.ts
@@ -36,8 +36,15 @@ export async function POST(request: Request) {
       );
     }
 
-    // For now, just return success since viewPreference field doesn't exist in schema
-    // TODO: Add viewPreference field to pesos_User model
+    const { setViewPreference } = await import("@/lib/cookies");
+
+    await prisma.pesos_User.update({
+      where: { id: userId },
+      data: { viewPreference: preference },
+    });
+
+    setViewPreference(preference as "simple" | "detailed");
+
     console.log(`User ${userId} set view preference to ${preference}`);
 
     return NextResponse.json({

--- a/changelog.md
+++ b/changelog.md
@@ -317,3 +317,8 @@ does not stretch too wide.
 
 **Simplified dashboard URLs and unified admin page.**
 Updated routes so `/dashboard` replaces `/dashboard/simple`, and `/dashboard/detailed` replaces `/dashboard/all_posts`. Added `/admin` page with password prompt showing server stats and admin logs together.
+
+## 2025-06-21
+
+**Added view preference storage.**
+Introduced `viewPreference` column on `pesos_User` with a migration and updated `/api/set-view-preference` to save the user's dashboard view choice in the database and cookie.

--- a/prisma/migrations/20250626120000_add_view_preference/migration.sql
+++ b/prisma/migrations/20250626120000_add_view_preference/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "pesos_User" ADD COLUMN "viewPreference" TEXT NOT NULL DEFAULT 'simple';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,6 +59,7 @@ model pesos_User {
   id          String              @id
   username    String              @unique
   createdAt   DateTime            @default(now())
+  viewPreference String           @default("simple")
   sources     pesos_UserSources[]
   pesos_items pesos_items[]
   linkPages   LinkPage[]

--- a/todo.md
+++ b/todo.md
@@ -51,6 +51,7 @@ A running list of tasks related to PESOS. May be edited by humans or agents.
   - [x] Immediate loading spinner for `/dashboard/simple`
   - [x] Simplify dashboard URLs (remove /simple, rename /all_posts to /detailed)
   - [x] Unify server stats and admin under `/admin`
+  - [x] Store dashboard view preference in database
 
 - [ ] **Data Export Enhancement** - Polish existing export functionality
   - [ ] Better export UI/UX


### PR DESCRIPTION
## Summary
- add `viewPreference` column to `pesos_User`
- store dashboard view choice in database and cookies via API
- create migration for new field
- document new feature in changelog
- mark todo item completed

## Testing
- `npx prisma generate` *(fails: 403 Forbidden for binaries.prisma.sh)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685543e4eab8832caa9866c5f3682b58