### PR TITLE
Add documentation section with export guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/deploym
 ## Stay Informed
 
 New features are rolling out all the time. Visit `/subscribe` on the running site to leave your email and get updates.
+
+## Documentation
+
+Browse `/docs` in the app for project notes and data format details.

--- a/app/docs/data-format/page.tsx
+++ b/app/docs/data-format/page.tsx
@@ -1,0 +1,27 @@
+export const metadata = { title: "Data Export Formats" };
+export const dynamic = "force-static";
+
+export default function DataFormatDoc() {
+  return (
+    <article className="prose mx-auto py-16">
+      <h1>Data Export Formats</h1>
+      <p>PESOS lets you download your archived data at any time. Exports are available in three formats:</p>
+      <h2>JSON</h2>
+      <ul>
+        <li>Complete representation of your user profile, connected sources and saved items.</li>
+        <li>Ideal for backing up or importing into other tools.</li>
+      </ul>
+      <h2>Markdown</h2>
+      <ul>
+        <li>A readable summary where each item becomes a Markdown entry.</li>
+        <li>Great for publishing or quick reviews.</li>
+      </ul>
+      <h2>CSV</h2>
+      <ul>
+        <li>Tabular data containing the same fields as the JSON export.</li>
+        <li>Useful for spreadsheets or custom scripts.</li>
+      </ul>
+      <p>All exports contain only your own content and can be generated from the dashboard. No additional authentication steps are required beyond being logged in.</p>
+    </article>
+  );
+}

--- a/app/docs/new-user-wizard/page.tsx
+++ b/app/docs/new-user-wizard/page.tsx
@@ -1,0 +1,12 @@
+export const metadata = { title: "New User Wizard" };
+export const dynamic = "force-static";
+
+export default function NewUserWizardDoc() {
+  return (
+    <article className="prose mx-auto py-16">
+      <h1>New User Wizard</h1>
+      <p>This document outlines a plan for a full-page multi-step setup wizard and inline editing pages. The wizard will help new users connect feeds and configure their profile with minimal friction.</p>
+      <p>See <code>docs/new-user-wizard.md</code> for the original notes.</p>
+    </article>
+  );
+}

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,0 +1,23 @@
+export const metadata = { title: "Documentation - PESOS" };
+
+const docs = [
+  { slug: "data-format", title: "Data Export Formats" },
+  { slug: "new-user-wizard", title: "New User Wizard" },
+];
+
+export default function DocsIndex() {
+  return (
+    <div className="max-w-3xl mx-auto py-16">
+      <h1 className="text-3xl font-bold mb-6">Documentation</h1>
+      <ul className="space-y-2">
+        {docs.map((doc) => (
+          <li key={doc.slug}>
+            <a href={`/docs/${doc.slug}`} className="text-blue-600 underline">
+              {doc.title}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/changelog.md
+++ b/changelog.md
@@ -322,3 +322,6 @@ Updated routes so `/dashboard` replaces `/dashboard/simple`, and `/dashboard/det
 
 **Added view preference storage.**
 Introduced `viewPreference` column on `pesos_User` with a migration and updated `/api/set-view-preference` to save the user's dashboard view choice in the database and cookie.
+
+**Added documentation section.**
+Created `/docs` route with a new "Data Export Formats" page explaining JSON, Markdown and CSV backups. Updated README and todo lists accordingly.

--- a/docs/data-format.md
+++ b/docs/data-format.md
@@ -1,0 +1,17 @@
+# Data Export Formats
+
+PESOS lets you download your archived data at any time. Exports are available in three formats:
+
+## JSON
+- Complete representation of your user profile, connected sources and saved items.
+- Ideal for backing up or importing into other tools.
+
+## Markdown
+- A readable summary where each item becomes a Markdown entry.
+- Great for publishing or quick reviews.
+
+## CSV
+- Tabular data containing the same fields as the JSON export.
+- Useful for spreadsheets or custom scripts.
+
+All exports contain only your own content and can be generated from the dashboard. No additional authentication steps are required beyond being logged in.

--- a/todo.md
+++ b/todo.md
@@ -143,6 +143,7 @@ A running list of tasks related to PESOS. May be edited by humans or agents.
   - [ ] API documentation
   - [ ] User guides
   - [ ] Developer documentation
+  - [x] Data export format guide
 - [ ] Performance optimization
   - [ ] Database indexing
   - [ ] Caching strategy


### PR DESCRIPTION
## Summary
- create `/docs` route with index and new pages
- document data export formats
- reference new docs in README
- mark export guide task done in todo
- log update in changelog

## Testing
- `bun test` *(fails: Cannot find module 'next/server')*
- `bun x next lint` *(fails: ERR_UNHANDLED_REJECTION)*

------
https://chatgpt.com/codex/tasks/task_e_685668d2a070832c83ee64c304ae7483